### PR TITLE
Attaching files on AppCenter crashes

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,2 @@
+# Contributors
+- [Victor Simon](https://github.com/engineearemotetechnologiessl)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ NLog Target for [Microsoft Visual Studio App Center with Azure](https://azure.mi
 - **AppSecret** - Appsecret for starting AppCenter if needed (optional)
 - **UserId** - Application UserId to register in AppCenter (optional)
 - **ReportExceptionAsCrash** - Report all exceptions as crashes to AppCenter (default=false)
+- **PathToCrashAttachmentDirectory** - Path to the files to be attached in crashes to AppCenter. All files are compressed before attaching them (optional)
 - **IncludeEventProperties** - Include LogEvent properties in AppCenter properties (default=true)
 - **IncludeMdlc** - Include MappedDiagnosticsLogicalContext (MLDC) that can be provided with MEL BeginScope (default=false)
 

--- a/src/NLog.Targets.AppCenter/AppCenterTarget.cs
+++ b/src/NLog.Targets.AppCenter/AppCenterTarget.cs
@@ -222,12 +222,21 @@ namespace NLog.Targets
                 {
                     var errorAttachement = Microsoft.AppCenter.Crashes.ErrorAttachmentLog.AttachmentWithBinary(
                                                                 System.IO.File.ReadAllBytes(compressedFile.FullName), 
-                                                                compressedFile.FullName,
+                                                                compressedFile.Name,
                                                                 "application/x-zip-compressed");                   
                     errorAttachements.Add(errorAttachement);
                 }
+                HouseKeeping(compressedFiles);
             }
             return errorAttachements;
+        }
+
+        private void HouseKeeping(List<System.IO.FileInfo> compressedFiles)
+        {
+            foreach (System.IO.FileInfo compressedFile in compressedFiles)
+            {
+                compressedFile.Delete();
+            }
         }
 
         private List<System.IO.FileInfo> Compress(System.IO.DirectoryInfo directorySelected)

--- a/src/NLog.Targets.AppCenter/AppCenterTarget.cs
+++ b/src/NLog.Targets.AppCenter/AppCenterTarget.cs
@@ -214,7 +214,7 @@ namespace NLog.Targets
         /// </remarks>
         private Microsoft.AppCenter.Crashes.ErrorAttachmentLog[] BuildAttachmentLogs(LogEventInfo logEvent)
         {
-            var path = RenderLogEvent(PathToCrashAttachmentDirectory, LogEventInfo.CreateNullEvent());
+            var path = RenderLogEvent(PathToCrashAttachmentDirectory, logEvent);
             if (!string.IsNullOrEmpty(path))
             {
                 var errorAttachements = new List<Microsoft.AppCenter.Crashes.ErrorAttachmentLog>();

--- a/src/NLog.Targets.AppCenter/AppCenterTarget.cs
+++ b/src/NLog.Targets.AppCenter/AppCenterTarget.cs
@@ -261,7 +261,6 @@ namespace NLog.Targets
                 catch (Exception ex)
                 {
                     InternalLogger.Error(ex, "BuildAttachmentLogs(Path={0}): Failed to attach directory content", path);
-                    throw;
                 }
                 return errorAttachements.ToArray();
             }


### PR DESCRIPTION
* Add directory path as parameter
* Compress all files in this directory
* Attach compressed files 
* Delete compressed files